### PR TITLE
release: v0.5.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@technote-space/genetic-algorithms-js",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "description": "Genetic Algorithms Library",
   "author": {
     "name": "Technote",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@typescript-eslint/parser": "^3.2.0",
     "eslint": "^7.2.0",
     "husky": "^4.2.5",
-    "lint-staged": "^10.2.9",
+    "lint-staged": "^10.2.10",
     "typescript": "^3.9.5"
   },
   "publishConfig": {

--- a/src/Algorithm/AlgorithmBase.ts
+++ b/src/Algorithm/AlgorithmBase.ts
@@ -50,7 +50,7 @@ export abstract class AlgorithmBase implements IAlgorithm {
     // eslint-disable-next-line no-magic-numbers
     this._chromosomes = this.islands.flatMap(island => island.population.chromosomes).sort((c1, c2) => (c2.fitness ?? -1.0) - (c1.fitness ?? -1.0));
     // eslint-disable-next-line no-magic-numbers
-    const bestFitness = this.best.fitness ?? -1;
+    const bestFitness = this?.best.fitness ?? -1;
     // eslint-disable-next-line no-magic-numbers
     if (bestFitness >= 0 && bestFitness !== this._fitness) {
       this._fitness = bestFitness;
@@ -79,7 +79,7 @@ export abstract class AlgorithmBase implements IAlgorithm {
 
     await Promise.all(this.islands.map(island => island.step()));
     await this.migration?.migrate(this);
-    this.updateChromosomes();
+    await this.updateChromosomes();
 
     this.performStep();
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -250,9 +250,9 @@ acorn-jsx@^5.2.0:
   integrity sha512-HiUX/+K2YpkpJ+SzBffkM/AQ2YE03S0U1kjTLVpoJdhZMOWy8qvXVN9JdLqv2QsaQ6MPYQIuNmwD8zOiYUofLQ==
 
 acorn@^7.2.0:
-  version "7.2.0"
-  resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.2.0.tgz#17ea7e40d7c8640ff54a694c889c26f31704effe"
-  integrity sha512-apwXVmYVpQ34m/i71vrApRrRKCWQnZZF1+npOD0WV5xZFfwWOmKGQ2RWlfdy9vWITsenisM8M0Qeq8agcFHNiQ==
+  version "7.3.1"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.3.1.tgz#85010754db53c3fbaf3b9ea3e083aa5c5d147ffd"
+  integrity sha512-tLc0wSnatxAQHVHUapaHdz72pi9KUyHjq5KyHjGg9Y8Ifdc79pTh2XvI6I1/chZbnM7QtNKzh66ooDogPZSleA==
 
 aggregate-error@^3.0.0:
   version "3.0.1"
@@ -1232,10 +1232,10 @@ lines-and-columns@^1.1.6:
   resolved "https://registry.yarnpkg.com/lines-and-columns/-/lines-and-columns-1.1.6.tgz#1c00c743b433cd0a4e80758f7b64a57440d9ff00"
   integrity sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=
 
-lint-staged@^10.2.9:
-  version "10.2.9"
-  resolved "https://registry.yarnpkg.com/lint-staged/-/lint-staged-10.2.9.tgz#6013ecfa80829cd422446b545fd30a96bca3098c"
-  integrity sha512-ziRAuXEqvJLSXg43ezBpHxRW8FOJCXISaXU//BWrxRrp5cBdRkIx7g5IsB3OI45xYGE0S6cOacfekSjDyDKF2g==
+lint-staged@^10.2.10:
+  version "10.2.10"
+  resolved "https://registry.yarnpkg.com/lint-staged/-/lint-staged-10.2.10.tgz#f0f78bf8786bbe90e1775a0dc540f7f12b6a79b2"
+  integrity sha512-dgelFaNH6puUGAcU+OVMgbfpKSerNYsPSn6+nlbRDjovL0KigpsVpCu0PFZG6BJxX8gnHJqaZlR9krZamQsb0w==
   dependencies:
     chalk "^4.0.0"
     cli-truncate "2.1.0"


### PR DESCRIPTION
<!-- START pr-commits   please keep comment here to allow auto update -->
## Changes


* chore: update npm dependencies (2c00511d808b88b28211141188378d14b4c04aad)
* chore: tweaks (bd789a396b00f8cbeafbc26f952c776f20e953d6)

<!-- END pr-commits   please keep comment here to allow auto update -->

## Base PullRequest

default branch (https://github.com/technote-space/genetic-algorithms-js/tree/master)

## Command results
<details>
<summary>Details: </summary>

<details>
<summary><em>add path</em></summary>

```Shell
/home/runner/work/_actions/technote-space/create-pr-action/v2/node_modules/npm-check-updates/bin
```



</details>
<details>
<summary><em>ncu -u --packageFile package.json</em></summary>

```Shell
Upgrading /home/runner/work/genetic-algorithms-js/genetic-algorithms-js/package.json

 lint-staged  ^10.2.9  →  ^10.2.10 

Run npm install to install new versions.
```



</details>
<details>
<summary><em>yarn install</em></summary>

```Shell
yarn install v1.22.4
[1/4] Resolving packages...
[2/4] Fetching packages...
[3/4] Linking dependencies...
[4/4] Building fresh packages...
success Saved lockfile.
Done in 9.65s.
```



</details>
<details>
<summary><em>yarn upgrade</em></summary>

```Shell
yarn upgrade v1.22.4
[1/4] Resolving packages...
[2/4] Fetching packages...
[3/4] Linking dependencies...
[4/4] Rebuilding all packages...
success Saved lockfile.
success Saved 224 new dependencies.
info Direct dependencies
├─ @commitlint/cli@8.3.5
├─ @commitlint/config-conventional@8.3.4
├─ @typescript-eslint/eslint-plugin@3.2.0
├─ @typescript-eslint/parser@3.2.0
├─ eslint@7.2.0
├─ husky@4.2.5
├─ lint-staged@10.2.10
└─ typescript@3.9.5
info All dependencies
├─ @babel/helper-validator-identifier@7.10.1
├─ @babel/highlight@7.10.1
├─ @commitlint/cli@8.3.5
├─ @commitlint/config-conventional@8.3.4
├─ @commitlint/ensure@8.3.4
├─ @commitlint/execute-rule@8.3.4
├─ @commitlint/format@8.3.4
├─ @commitlint/is-ignored@8.3.5
├─ @commitlint/lint@8.3.5
├─ @commitlint/load@8.3.5
├─ @commitlint/message@8.3.4
├─ @commitlint/parse@8.3.4
├─ @commitlint/read@8.3.4
├─ @commitlint/resolve-extends@8.3.5
├─ @commitlint/rules@8.3.4
├─ @commitlint/to-lines@8.3.4
├─ @commitlint/top-level@8.3.4
├─ @marionebl/sander@0.6.1
├─ @types/color-name@1.1.1
├─ @types/eslint-visitor-keys@1.0.0
├─ @types/json-schema@7.0.5
├─ @types/minimist@1.2.0
├─ @types/normalize-package-data@2.4.0
├─ @types/parse-json@4.0.0
├─ @typescript-eslint/eslint-plugin@3.2.0
├─ @typescript-eslint/parser@3.2.0
├─ acorn-jsx@5.2.0
├─ acorn@7.3.1
├─ aggregate-error@3.0.1
├─ ajv@6.12.2
├─ ansi-colors@3.2.4
├─ ansi-escapes@4.3.1
├─ ansi-regex@5.0.0
├─ argparse@1.0.10
├─ array-find-index@1.0.2
├─ array-ify@1.0.0
├─ babel-polyfill@6.26.0
├─ balanced-match@1.0.0
├─ brace-expansion@1.1.11
├─ braces@3.0.2
├─ caller-callsite@2.0.0
├─ caller-path@2.0.0
├─ callsites@3.1.0
├─ camelcase-keys@6.2.2
├─ chardet@0.7.0
├─ ci-info@2.0.0
├─ clean-stack@2.2.0
├─ cli-truncate@2.1.0
├─ cli-width@2.2.1
├─ color-convert@2.0.1
├─ color-name@1.1.4
├─ commander@5.1.0
├─ compare-versions@3.6.0
├─ concat-map@0.0.1
├─ conventional-changelog-angular@1.6.6
├─ conventional-changelog-conventionalcommits@4.2.1
├─ conventional-commits-parser@3.1.0
├─ core-js@2.6.11
├─ core-util-is@1.0.2
├─ cross-spawn@7.0.3
├─ currently-unhandled@0.4.1
├─ dargs@7.0.0
├─ decamelize-keys@1.1.0
├─ decamelize@1.2.0
├─ dedent@0.7.0
├─ deep-is@0.1.3
├─ doctrine@3.0.0
├─ dot-prop@3.0.0
├─ emoji-regex@8.0.0
├─ end-of-stream@1.4.4
├─ enquirer@2.3.5
├─ eslint-scope@5.1.0
├─ eslint@7.2.0
├─ espree@7.1.0
├─ esprima@4.0.1
├─ esquery@1.3.1
├─ esrecurse@4.2.1
├─ estraverse@4.3.0
├─ execa@4.0.2
├─ external-editor@3.1.0
├─ fast-deep-equal@3.1.3
├─ fast-json-stable-stringify@2.1.0
├─ fast-levenshtein@2.0.6
├─ figures@3.2.0
├─ file-entry-cache@5.0.1
├─ fill-range@7.0.1
├─ find-versions@3.2.0
├─ flat-cache@2.0.1
├─ flatted@2.0.2
├─ fs.realpath@1.0.0
├─ get-own-enumerable-property-symbols@3.0.2
├─ get-stdin@7.0.0
├─ get-stream@5.1.0
├─ git-raw-commits@2.0.7
├─ glob-parent@5.1.1
├─ global-dirs@0.1.1
├─ globals@12.4.0
├─ graceful-fs@4.2.4
├─ hard-rejection@2.1.0
├─ has-flag@4.0.0
├─ hosted-git-info@2.8.8
├─ human-signals@1.1.1
├─ husky@4.2.5
├─ iconv-lite@0.4.24
├─ ignore@4.0.6
├─ import-fresh@3.2.1
├─ imurmurhash@0.1.4
├─ inflight@1.0.6
├─ inherits@2.0.4
├─ ini@1.3.5
├─ inquirer@7.1.0
├─ is-arrayish@0.2.1
├─ is-directory@0.3.1
├─ is-extglob@2.1.1
├─ is-number@7.0.0
├─ is-obj@1.0.1
├─ is-regexp@1.0.0
├─ is-stream@2.0.0
├─ is-text-path@1.0.1
├─ isarray@1.0.0
├─ isexe@2.0.0
├─ js-tokens@4.0.0
├─ json-schema-traverse@0.4.1
├─ json-stable-stringify-without-jsonify@1.0.1
├─ jsonparse@1.3.1
├─ JSONStream@1.3.5
├─ kind-of@6.0.3
├─ lines-and-columns@1.1.6
├─ lint-staged@10.2.10
├─ listr2@2.1.3
├─ load-json-file@4.0.0
├─ locate-path@5.0.0
├─ lodash.template@4.5.0
├─ lodash.templatesettings@4.2.0
├─ log-symbols@4.0.0
├─ log-update@4.0.0
├─ loud-rejection@1.6.0
├─ map-obj@1.0.1
├─ merge-stream@2.0.0
├─ micromatch@4.0.2
├─ mimic-fn@2.1.0
├─ min-indent@1.0.1
├─ minimist-options@4.1.0
├─ minimist@1.2.5
├─ ms@2.1.2
├─ mute-stream@0.0.8
├─ natural-compare@1.4.0
├─ normalize-path@3.0.0
├─ npm-run-path@4.0.1
├─ once@1.4.0
├─ opencollective-postinstall@2.0.3
├─ optionator@0.9.1
├─ os-tmpdir@1.0.2
├─ p-limit@2.3.0
├─ p-locate@4.1.0
├─ p-map@4.0.0
├─ p-try@2.2.0
├─ parent-module@1.0.1
├─ path-exists@4.0.0
├─ path-is-absolute@1.0.1
├─ path-key@3.1.1
├─ path-parse@1.0.6
├─ path-type@4.0.0
├─ picomatch@2.2.2
├─ pkg-dir@4.2.0
├─ process-nextick-args@2.0.1
├─ progress@2.0.3
├─ pump@3.0.0
├─ punycode@2.1.1
├─ quick-lru@4.0.1
├─ read-pkg-up@7.0.1
├─ read-pkg@5.2.0
├─ readable-stream@3.6.0
├─ redent@3.0.0
├─ regenerator-runtime@0.10.5
├─ regexpp@3.1.0
├─ resolve-global@1.0.0
├─ resolve@1.17.0
├─ restore-cursor@3.1.0
├─ rimraf@2.6.3
├─ run-async@2.4.1
├─ rxjs@6.5.5
├─ safe-buffer@5.1.2
├─ safer-buffer@2.1.2
├─ semver-compare@1.0.0
├─ semver-regex@2.0.0
├─ semver@7.3.2
├─ shebang-command@2.0.0
├─ shebang-regex@3.0.0
├─ slash@3.0.0
├─ slice-ansi@2.1.0
├─ spdx-correct@3.1.1
├─ spdx-exceptions@2.3.0
├─ sprintf-js@1.0.3
├─ string_decoder@1.3.0
├─ string-argv@0.3.1
├─ stringify-object@3.3.0
├─ strip-bom@3.0.0
├─ strip-final-newline@2.0.0
├─ strip-indent@3.0.0
├─ strip-json-comments@3.1.0
├─ table@5.4.6
├─ text-extensions@1.9.0
├─ text-table@0.2.0
├─ through@2.3.8
├─ tmp@0.0.33
├─ to-regex-range@5.0.1
├─ trim-newlines@3.0.0
├─ trim-off-newlines@1.0.1
├─ tslib@1.13.0
├─ type-check@0.4.0
├─ typescript@3.9.5
├─ uri-js@4.2.2
├─ util-deprecate@1.0.2
├─ v8-compile-cache@2.1.1
├─ validate-npm-package-license@3.0.4
├─ which-pm-runs@1.0.0
├─ which@2.0.2
├─ word-wrap@1.2.3
├─ wrap-ansi@6.2.0
├─ write@1.0.3
├─ xtend@4.0.2
├─ yaml@1.10.0
└─ yargs-parser@18.1.3
Done in 3.33s.
```

### stderr:

```Shell
warning @commitlint/cli > babel-polyfill > core-js@2.6.11: core-js@<3 is no longer maintained and not recommended for usage due to the number of issues. Please, upgrade your dependencies to the actual version of core-js@3.
warning @commitlint/cli > babel-polyfill > babel-runtime > core-js@2.6.11: core-js@<3 is no longer maintained and not recommended for usage due to the number of issues. Please, upgrade your dependencies to the actual version of core-js@3.
```

</details>
<details>
<summary><em>yarn audit</em></summary>

```Shell
yarn audit v1.22.4
┌───────────────┬──────────────────────────────────────────────────────────────┐
│ low           │ Prototype Pollution                                          │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Package       │ yargs-parser                                                 │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Patched in    │ >=13.1.2 <14.0.0 || >=15.0.1 <16.0.0 || >=18.1.2             │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Dependency of │ @commitlint/cli                                              │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Path          │ @commitlint/cli > meow > yargs-parser                        │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ More info     │ https://www.npmjs.com/advisories/1500                        │
└───────────────┴──────────────────────────────────────────────────────────────┘
1 vulnerabilities found - Packages audited: 356
Severity: 1 Low
Done in 0.51s.
```



</details>

</details>

## Changed files
<details>
<summary>Changed 2 files: </summary>

- package.json
- yarn.lock

</details>

<hr>

[:octocat: Repo](https://github.com/technote-space/create-pr-action) | [:memo: Issues](https://github.com/technote-space/create-pr-action/issues) | [:department_store: Marketplace](https://github.com/marketplace/actions/create-pr-action)